### PR TITLE
Fix: Not working in Blender 5.0 #41

### DIFF
--- a/Core/Animator/LIPSYNC2D_PoseAssetsAnimator.py
+++ b/Core/Animator/LIPSYNC2D_PoseAssetsAnimator.py
@@ -177,14 +177,43 @@ class LIPSYNC2D_PoseAssetsAnimator:
         :param interpolation: The interpolation type for the keyframes.
         :type interpolation: Literal["LINEAR"]
         """
+        # Determine where to read the pose asset fcurves from. In newer Blender
+        # APIs pose assets may not expose `.fcurves` directly; the pose data is
+        # stored in the action's first layer/strip channelbag. Fall back to
+        # `pose_action.fcurves` when available.
+        pose_fcurves = None
+
+        # Try to get fcurves from the pose asset's strip channelbag first
+        try:
+            if hasattr(pose_action, "layers") and len(pose_action.layers) > 0:
+                pose_strip = pose_action.layers[0].strips[0]
+                # Use first slot if present
+                pose_slot = pose_action.slots[0] if getattr(pose_action, "slots", None) else None
+                if pose_strip is not None and pose_slot is not None:
+                    pose_channelbag = pose_strip.channelbag(pose_slot)
+                    pose_fcurves = getattr(pose_channelbag, "fcurves", None)
+        except Exception:
+            pose_fcurves = None
+
+        # Fallback to action.fcurves when present
+        if pose_fcurves is None:
+            pose_fcurves = getattr(pose_action, "fcurves", None)
+
+        if pose_fcurves is None:
+            # Nothing we can copy from
+            return
+
         for fcurve in self.channelbag.fcurves:
-            pose_asset_fcurve = pose_action.fcurves.find(
+            pose_asset_fcurve = pose_fcurves.find(
                 fcurve.data_path, index=fcurve.array_index
             )
             if pose_asset_fcurve is None:
                 continue
 
             # Since Action is from a Pose Asset, we can safely assume that first keyframe point holds the Pose
+            if len(pose_asset_fcurve.keyframe_points) == 0:
+                continue
+
             fcurve_value = pose_asset_fcurve.keyframe_points[0].co.y
             kframe = fcurve.keyframe_points.insert(
                 frame,

--- a/Core/Animator/LIPSYNC_SpriteSheetAnimator.py
+++ b/Core/Animator/LIPSYNC_SpriteSheetAnimator.py
@@ -57,11 +57,29 @@ class LIPSYNC_SpriteSheetAnimator:
         :type obj: BpyObject
         :return: None
         """
-        action = obj.animation_data.action if obj.animation_data else None
-        if action:
-            for fcurve in action.fcurves:
+        if (action := obj.animation_data.action) is None:
+            return
+
+        # Retrieve the strip and channelbag correctly for Layered Actions
+        # Assuming single layer/strip structure as per setup()
+        if not action.layers or not action.layers[0].strips:
+             return
+
+        strip = cast(BpyActionKeyframeStrip, action.layers[0].strips[0])
+        
+        # Ensure we get the correct slot for sprite sheet
+        slot = action.slots.get(f"OB{SLOT_SPRITE_SHEET_NAME}")
+        if not slot:
+             return
+
+        try:
+             channelbag = strip.channelbag(slot)
+             for fcurve in channelbag.fcurves:
                 if fcurve.data_path == "lipsync2d_props.lip_sync_2d_sprite_sheet_index":
                     fcurve.keyframe_points.clear()
+        except Exception:
+             # Fallback or silence if channelbag creation fails (though it should exist if we are clearing)
+             pass
 
     def insert_keyframes(self, obj: BpyObject, props: BpyPropertyGroup, visemes_data: VisemeData,
                          word_timing: WordTiming,
@@ -203,12 +221,29 @@ class LIPSYNC_SpriteSheetAnimator:
         :type obj: BpyObject
         :return: None
         """
-        action = obj.animation_data.action if obj.animation_data else None
+        if (action := obj.animation_data.action) is None:
+             return
+        
+        # We can try to use self.channelbag if it's already set up, but to be robust
+        # we re-fetch it similar to clear_previous_keyframes to ensure we have the right one.
+        
+        if not action.layers or not action.layers[0].strips:
+             return
 
-        if action:
-            for fcurve in action.fcurves:
+        strip = cast(BpyActionKeyframeStrip, action.layers[0].strips[0])
+        # Ensure we get the correct slot for sprite sheet
+        slot = action.slots.get(f"OB{SLOT_SPRITE_SHEET_NAME}")
+        
+        if not slot:
+             return
+
+        try:
+            channelbag = strip.channelbag(slot)
+            for fcurve in channelbag.fcurves:
                 for keyframe in fcurve.keyframe_points:
                     keyframe.interpolation = 'CONSTANT'
+        except Exception:
+            pass
 
     def setup(self, obj: BpyObject):
         self.setup_animation_properties(obj)


### PR DESCRIPTION
This is the keyframing Fix for Blender 5.0 that tries to read data from layers. This was the code provided by https://github.com/AntoniBlender in #https://github.com/Charley3d/lip-sync/issues/39 comments. Testing so far shows it is working to keyframe poses.

This also includes code to fix keyframing for spritesheets and shapekeys asa well.