### PR TITLE
Feature: Allow Baking of a Single Channel from Sequencer

### DIFF
--- a/Panels/AnimatorPanelMixin.py
+++ b/Panels/AnimatorPanelMixin.py
@@ -102,3 +102,6 @@ class AnimatorPanelMixin:
             row.prop(self.props, "lip_sync_2d_bake_start", text="Start")
             row.prop(self.props, "lip_sync_2d_bake_end", text="End")
             row.enabled = self.props.lip_sync_2d_use_bake_range  # type: ignore
+
+            row = panel_body.row()
+            row.prop(self.props, "lip_sync_2d_bake_channel")

--- a/Properties/LIPSYNC2D_PG_CustomProperties.py
+++ b/Properties/LIPSYNC2D_PG_CustomProperties.py
@@ -157,7 +157,35 @@ def poll_pose_assets(self, obj: bpy.types.ID):
     return bool(obj.asset_data)
 
 
+def get_channel_items(self, context: BpyContext | None):
+    items = [("ALL", "All Channels", "Bake audio from all channels")]
+
+    if context is None or context.scene is None or context.scene.sequence_editor is None:
+        return intern_enum_items(items)
+
+    channels = set()
+    for strip in context.scene.sequence_editor.strips_all:
+        if strip.type == "SOUND" and not strip.mute:
+            channels.add(strip.channel)
+
+    sorted_channels = sorted(list(channels))
+    
+    for channel in sorted_channels:
+        c_data = context.scene.sequence_editor.channels[channel]
+        channel_name = str(channel)+" - "+c_data.name
+        if c_data.mute:
+            channel_name += " (Muted)"
+        items.append((str(channel), channel_name, f"Bake audio from Channel {channel}"))
+    return intern_enum_items(items)
+
+
 class LIPSYNC2D_PG_CustomProperties(bpy.types.PropertyGroup):
+    lip_sync_2d_bake_channel: bpy.props.EnumProperty(
+        name="Channel",
+        description="Select specific channel to bake audio from",
+        items=get_channel_items
+    )  # type: ignore
+
     lip_sync_2d_initialized: bpy.props.BoolProperty(
         name="Initilize Lip Sync",
         description="Initilize Lip Sync on selection",


### PR DESCRIPTION
This PR introduces a dropdown menu in the Bake Settings Panel that shows a list of channels that have audio in them and a selection for all channels. If "All Channels" is selected, then the extension works the same as before. Otherwise it only works on the the audio from the selected channel. Muted channels are noted in the dropdown as well.


It works by temporarily muting all the other channels before mixdown. Then unmutes them afterwards. 

<img width="498" height="406" alt="image" src="https://github.com/user-attachments/assets/1147b9c7-d4e9-41f7-9571-318543e3ecea" />

Tested in 4.5.2