### PR TITLE
Save / Load Viseme Settings

### DIFF
--- a/Operators/LIPSYNC2D_OT_ExportImportMappings.py
+++ b/Operators/LIPSYNC2D_OT_ExportImportMappings.py
@@ -76,6 +76,12 @@ class LIPSYNC2D_OT_ImportMappings(bpy.types.Operator, ImportHelper):
         maxlen=255,
     ) # type: ignore
 
+    create_missing: bpy.props.BoolProperty(
+        name="Create Missing",
+        description="Create missing Shape Keys or Actions if they don't exist",
+        default=False,
+    ) # type: ignore
+
     def execute(self, context):
         obj = context.active_object
         if not obj or not hasattr(obj, "lipsync2d_props"):
@@ -105,6 +111,7 @@ class LIPSYNC2D_OT_ImportMappings(bpy.types.Operator, ImportHelper):
 
         loaded_count = 0
         skipped_count = 0
+        created_count = 0
 
         for item in mappings:
             viseme_id = item.get("viseme")
@@ -132,6 +139,19 @@ class LIPSYNC2D_OT_ImportMappings(bpy.types.Operator, ImportHelper):
                     elif obj.data and obj.data.shape_keys and mapping_value in obj.data.shape_keys.key_blocks:
                         setattr(props, prop_name, mapping_value)
                         loaded_count += 1
+                    elif self.create_missing:
+                        # Ensure Basis key exists first
+                        if not obj.data.shape_keys:
+                            obj.shape_key_add(name="Basis")
+                        
+                        obj.shape_key_add(name=mapping_value)
+                        # We need to refresh the EnumProperty somehow or just set the string if it allows (usually it stores string index)
+                        # For now, just setting the string property should work if the Enum updates dynamically or if it's a StringProperty storage.
+                        # However, for EnumProperty backed by a function, setting the string *should* work if the item is now in the list.
+                        # Since we just added it to key_blocks, it should be valid.
+                        setattr(props, prop_name, mapping_value)
+                        created_count += 1
+                        loaded_count += 1
                     else:
                         self.report({'INFO'}, f"Skipped '{viseme_id}': Shape Key '{mapping_value}' not found on object.")
                         skipped_count += 1
@@ -151,6 +171,13 @@ class LIPSYNC2D_OT_ImportMappings(bpy.types.Operator, ImportHelper):
                         if action:
                             setattr(props, prop_name, action)
                             loaded_count += 1
+                        elif self.create_missing:
+                            new_action = bpy.data.actions.new(name=mapping_value)
+                            # Mark as asset so it appears in the filtered dropdowns
+                            new_action.asset_mark()
+                            setattr(props, prop_name, new_action)
+                            created_count += 1
+                            loaded_count += 1
                         else:
                             self.report({'INFO'}, f"Skipped '{viseme_id}': Action '{mapping_value}' not found in blend file.")
                             skipped_count += 1
@@ -158,5 +185,5 @@ class LIPSYNC2D_OT_ImportMappings(bpy.types.Operator, ImportHelper):
                     self.report({'INFO'}, f"Skipped '{viseme_id}': Property '{prop_name}' not found.")
                     skipped_count += 1
 
-        self.report({'INFO'}, f"Imported {loaded_count} mappings. Skipped {skipped_count}.")
+        self.report({'INFO'}, f"Imported {loaded_count} mappings. Created {created_count} missing items. Skipped {skipped_count}.")
         return {'FINISHED'}

--- a/Operators/LIPSYNC2D_OT_ExportImportMappings.py
+++ b/Operators/LIPSYNC2D_OT_ExportImportMappings.py
@@ -1,0 +1,162 @@
+import json
+import bpy
+from bpy_extras.io_utils import ExportHelper, ImportHelper
+from ..Core.phoneme_to_viseme import viseme_items_mpeg4_v2
+
+class LIPSYNC2D_OT_ExportMappings(bpy.types.Operator, ExportHelper):
+    """Export Viseme Mappings to JSON"""
+    bl_idname = "lipsync2d.export_mappings"
+    bl_label = "Export Mappings"
+    filename_ext = ".json"
+
+    filter_glob: bpy.props.StringProperty(
+        default="*.json",
+        options={'HIDDEN'},
+        maxlen=255,
+    ) # type: ignore
+
+    def execute(self, context):
+        obj = context.active_object
+        if not obj or not hasattr(obj, "lipsync2d_props"):
+            self.report({'ERROR'}, "No valid object selected")
+            return {'CANCELLED'}
+
+        props = obj.lipsync2d_props
+        anim_type = props.lip_sync_2d_lips_type
+        
+        data = {
+            "animation_type": anim_type,
+            "mappings": []
+        }
+
+        visemes = viseme_items_mpeg4_v2(None, None)
+        
+        for v in visemes:
+            viseme_id = v[0] # "sil", "PP", etc.
+            mapping_value = None
+
+            if anim_type == "SPRITESHEET":
+                prop_name = f"lip_sync_2d_viseme_{viseme_id}"
+                mapping_value = getattr(props, prop_name)
+            elif anim_type == "SHAPEKEYS":
+                prop_name = f"lip_sync_2d_viseme_shape_keys_{viseme_id}"
+                mapping_value = getattr(props, prop_name)
+            elif anim_type == "POSEASSETS":
+                prop_name = f"lip_sync_2d_viseme_pose_{viseme_id}"
+                action = getattr(props, prop_name)
+                if action:
+                    mapping_value = action.name
+            
+            if mapping_value is not None:
+                data["mappings"].append({
+                    "viseme": viseme_id,
+                    "mapping": mapping_value
+                })
+
+        try:
+            with open(self.filepath, 'w', encoding='utf-8') as f:
+                json.dump(data, f, indent=4)
+            self.report({'INFO'}, f"Mappings exported to {self.filepath}")
+        except Exception as e:
+            self.report({'ERROR'}, f"Failed to export mappings: {str(e)}")
+            return {'CANCELLED'}
+
+        return {'FINISHED'}
+
+
+class LIPSYNC2D_OT_ImportMappings(bpy.types.Operator, ImportHelper):
+    """Import Viseme Mappings from JSON"""
+    bl_idname = "lipsync2d.import_mappings"
+    bl_label = "Import Mappings"
+    filename_ext = ".json"
+
+    filter_glob: bpy.props.StringProperty(
+        default="*.json",
+        options={'HIDDEN'},
+        maxlen=255,
+    ) # type: ignore
+
+    def execute(self, context):
+        obj = context.active_object
+        if not obj or not hasattr(obj, "lipsync2d_props"):
+            self.report({'ERROR'}, "No valid object selected")
+            return {'CANCELLED'}
+
+        props = obj.lipsync2d_props
+        current_anim_type = props.lip_sync_2d_lips_type
+
+        try:
+            with open(self.filepath, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        except Exception as e:
+            self.report({'ERROR'}, f"Failed to read file: {str(e)}")
+            return {'CANCELLED'}
+
+        file_anim_type = data.get("animation_type")
+        if file_anim_type != current_anim_type:
+            self.report({'ERROR'}, f"Animation type mismatch. File: {file_anim_type}, Object: {current_anim_type}")
+            return {'CANCELLED'}
+
+        mappings = data.get("mappings", [])
+        
+        # Helper to check if property exists on the object (for version compatibility)
+        def prop_exists(prop_name):
+            return hasattr(props, prop_name)
+
+        loaded_count = 0
+        skipped_count = 0
+
+        for item in mappings:
+            viseme_id = item.get("viseme")
+            mapping_value = item.get("mapping")
+
+            if not viseme_id:
+                continue
+
+            if current_anim_type == "SPRITESHEET":
+                prop_name = f"lip_sync_2d_viseme_{viseme_id}"
+                if prop_exists(prop_name):
+                    setattr(props, prop_name, int(mapping_value))
+                    loaded_count += 1
+                else:
+                    self.report({'INFO'}, f"Skipped '{viseme_id}': Property '{prop_name}' not found.")
+                    skipped_count += 1
+
+            elif current_anim_type == "SHAPEKEYS":
+                prop_name = f"lip_sync_2d_viseme_shape_keys_{viseme_id}"
+                if prop_exists(prop_name):
+                    # Check if shape key exists on the mesh or if it is "NONE"
+                    if mapping_value == "NONE":
+                        setattr(props, prop_name, mapping_value)
+                        loaded_count += 1
+                    elif obj.data and obj.data.shape_keys and mapping_value in obj.data.shape_keys.key_blocks:
+                        setattr(props, prop_name, mapping_value)
+                        loaded_count += 1
+                    else:
+                        self.report({'INFO'}, f"Skipped '{viseme_id}': Shape Key '{mapping_value}' not found on object.")
+                        skipped_count += 1
+                else:
+                    self.report({'INFO'}, f"Skipped '{viseme_id}': Property '{prop_name}' not found.")
+                    skipped_count += 1
+
+            elif current_anim_type == "POSEASSETS":
+                prop_name = f"lip_sync_2d_viseme_pose_{viseme_id}"
+                if prop_exists(prop_name):
+                    if mapping_value == "None" or not mapping_value:
+                        setattr(props, prop_name, None)
+                        loaded_count += 1
+                    else:
+                        # Check if Action exists in bpy.data.actions
+                        action = bpy.data.actions.get(mapping_value)
+                        if action:
+                            setattr(props, prop_name, action)
+                            loaded_count += 1
+                        else:
+                            self.report({'INFO'}, f"Skipped '{viseme_id}': Action '{mapping_value}' not found in blend file.")
+                            skipped_count += 1
+                else:
+                    self.report({'INFO'}, f"Skipped '{viseme_id}': Property '{prop_name}' not found.")
+                    skipped_count += 1
+
+        self.report({'INFO'}, f"Imported {loaded_count} mappings. Skipped {skipped_count}.")
+        return {'FINISHED'}

--- a/Panels/LIPSYNC2D_PT_Panel.py
+++ b/Panels/LIPSYNC2D_PT_Panel.py
@@ -78,6 +78,10 @@ class LIPSYNC2D_PT_Panel(bpy.types.Panel):
         row.label(text="Animation type")
         row.prop(props, "lip_sync_2d_lips_type", text="")
 
+        row = layout.row(align=True)
+        row.operator("lipsync2d.export_mappings", text="Export Viseme Mappings", icon="EXPORT")
+        row.operator("lipsync2d.import_mappings", text="Import Viseme Mappings", icon="IMPORT")
+
         if self.animator_panel is None:
             return
 

--- a/__init__.py
+++ b/__init__.py
@@ -12,6 +12,7 @@ from .Operators.LIPSYNC2D_OT_RemoveLipSync import LIPSYNC2D_OT_RemoveLipSync
 from .Operators.LIPSYNC2D_OT_RemoveNodeGroups import LIPSYNC2D_OT_RemoveNodeGroups
 from .Operators.LIPSYNC2D_OT_SetCustomProperties import LIPSYNC2D_OT_SetCustomProperties
 from .Operators.LIPSYNC2D_OT_SetMouthArea import LIPSYNC2D_OT_SetMouthArea
+from .Operators.LIPSYNC2D_OT_ExportImportMappings import LIPSYNC2D_OT_ExportMappings, LIPSYNC2D_OT_ImportMappings
 from .Panels.LIPSYNC2D_PT_Panel import LIPSYNC2D_PT_Panel
 from .Panels.LIPSYNC2D_PT_Settings import LIPSYNC2D_PT_Settings
 from .Panels.LIPSYNC2D_PT_Edit import LIPSYNC2D_PT_Edit
@@ -35,6 +36,8 @@ def register():
     bpy.utils.register_class(LIPSYNC2D_OT_DownloadModelsList)
     bpy.utils.register_class(LIPSYNC2D_OT_RemoveLipSync)
     bpy.utils.register_class(LIPSYNC2D_OT_RemoveNodeGroups)
+    bpy.utils.register_class(LIPSYNC2D_OT_ExportMappings)
+    bpy.utils.register_class(LIPSYNC2D_OT_ImportMappings)
     bpy.utils.register_class(LIPSYNC2D_PT_Edit)
     bpy.utils.register_class(LIPSYNC2D_OT_RemoveAnimations)
     bpy.utils.register_class(LIPSYNC2D_OT_refresh_pose_assets)
@@ -52,6 +55,8 @@ def unregister():
     bpy.utils.unregister_class(LIPSYNC2D_OT_DownloadModelsList)
     bpy.utils.unregister_class(LIPSYNC2D_OT_RemoveLipSync)
     bpy.utils.unregister_class(LIPSYNC2D_OT_RemoveNodeGroups)
+    bpy.utils.unregister_class(LIPSYNC2D_OT_ExportMappings)
+    bpy.utils.unregister_class(LIPSYNC2D_OT_ImportMappings)
     bpy.utils.unregister_class(LIPSYNC2D_PT_Edit)
     bpy.utils.unregister_class(LIPSYNC2D_OT_RemoveAnimations)
     bpy.utils.unregister_class(LIPSYNC2D_OT_refresh_pose_assets)


### PR DESCRIPTION
This exports a json file with the viseme mappings.

**Saving**
The current animation type is exported only.

**Loading**
If the current animation mode does not match the file, it fails
If a viseme doesn't exist in the current version of the plugin, it will skip it (for version compatibility)

In the import file dialog there is a "Create Missing" checkbox

If Create Missing is unchecked
  - If a pose doesn't exist in the current file, skip it
  - if the object does not have a shape key with the same name as the one being imported, skip it
 
If Create Missing is checked
  - If a pose doesn't exist in the current file, create an empty pose asset with that name
  - if the object does not have a shape key with the same name as the one being imported, create an empty shape key on the object. If the object does not have a basis shape key, it will be added first.
